### PR TITLE
Update package dependencies

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
- platform :ios, '10.0'
+ platform :ios, '13.0'
 
 target 'WeChatMoments' do
   # Comment the next line if you don't want to use dynamic frameworks
@@ -14,6 +14,16 @@ target 'WeChatMoments' do
   target 'WeChatMomentsTests' do
     inherit! :search_paths
     pod 'OHHTTPStubs/Swift'
+  end
+
+  post_install do |installer|
+      installer.generated_projects.each do |project|
+            project.targets.each do |target|
+                target.build_configurations.each do |config|
+                    config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+                 end
+            end
+     end
   end
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (5.4.1)
+  - Alamofire (5.7.1)
   - MBProgressHUD (0.9.2)
   - OHHTTPStubs/Core (9.1.0)
   - OHHTTPStubs/Default (9.1.0):
@@ -14,14 +14,14 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - OHHTTPStubs/Swift (9.1.0):
     - OHHTTPStubs/Default
-  - PromiseKit (6.13.1):
-    - PromiseKit/CorePromise (= 6.13.1)
-    - PromiseKit/Foundation (= 6.13.1)
-    - PromiseKit/UIKit (= 6.13.1)
-  - PromiseKit/CorePromise (6.13.1)
-  - PromiseKit/Foundation (6.13.1):
+  - PromiseKit (6.18.1):
+    - PromiseKit/CorePromise (= 6.18.1)
+    - PromiseKit/Foundation (= 6.18.1)
+    - PromiseKit/UIKit (= 6.18.1)
+  - PromiseKit/CorePromise (6.18.1)
+  - PromiseKit/Foundation (6.18.1):
     - PromiseKit/CorePromise
-  - PromiseKit/UIKit (6.13.1):
+  - PromiseKit/UIKit (6.18.1):
     - PromiseKit/CorePromise
   - SwiftyJSON (4.3.0)
 
@@ -41,12 +41,12 @@ SPEC REPOS:
     - SwiftyJSON
 
 SPEC CHECKSUMS:
-  Alamofire: 2291f7d21ca607c491dd17642e5d40fdcda0e65c
+  Alamofire: 0123a34370cb170936ae79a8df46cc62b2edeb88
   MBProgressHUD: 1569cf7ace17a8bac47aabfbb8580a49690386d1
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  PromiseKit: 28fda91c973cc377875d8c0ea4f973013c05b6db
+  PromiseKit: 49d70c53d5d20e346beaea4b276b5dd2ab446bb4
   SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
 
-PODFILE CHECKSUM: 3a7acfa1d384b7685277ac0c46b099886e923cd5
+PODFILE CHECKSUM: f42c73463bdd41395ace306c38d791f6cdfc64d0
 
-COCOAPODS: 1.11.0
+COCOAPODS: 1.12.1


### PR DESCRIPTION
We need to update the pod dependencies for this project as Xcode 14 does not support deployment targets less than `11.0`. The `post_install` block ensures the setting is also applied to the Pods.